### PR TITLE
:lipstick: fix line-height with 'leading-normal'

### DIFF
--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -17,7 +17,7 @@ const NavLink: React.FC<PropsWithChildren<Pick<LinkProps, "to">>> = ({
       to={to}
       prefetch="intent"
       className={({ isActive }) =>
-        classNames("rounded-sm py-2.5 px-4 font-bold uppercase", {
+        classNames("rounded-sm p-3 font-bold uppercase", {
           "bg-neutral-900 text-white": isActive,
         })
       }

--- a/app/components/title.tsx
+++ b/app/components/title.tsx
@@ -31,6 +31,7 @@ export const Title: React.FC<Props> = ({
         "mb-4 inline-block p-2 font-bold tablet:px-4",
         {
           "bg-black": withBackground,
+          "p-5": withBackground,
         },
       )}
     >

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type {
   HeadersFunction,
   LinksFunction,

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -59,7 +59,7 @@ export default function Component() {
         {data.conference.description}
       </p>
 
-      <section className="pt-12 pb-8">
+      <section className="pt-12">
         <Title as="h2" withBackground size="text-6xl">
           Program
         </Title>

--- a/app/routes/talk.$slug.tsx
+++ b/app/routes/talk.$slug.tsx
@@ -50,6 +50,7 @@ export default function Component() {
         withBackground
         size="text-3xl"
         className={classNames(
+          "p-4",
           talk.title && talk.title.length > 40
             ? "laptop:text-5xl"
             : "laptop:text-6xl",


### PR DESCRIPTION
Remove custom padding from inside of Title component, and make its text-height consistent across sizes.

Any custom padding that needs to be added should be passed to the Title component in the classNames param.

Also modified the padding passed to Title in places where the padding was not even arount the text. (As a rule of thumb, simpler padding rules look better).